### PR TITLE
moss: refactor build script add ability to configure backends

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -371,16 +371,16 @@
         };
 
         nextpnr-xilinx-chipdb = {
-          artiz7 = final._nextpnr-xilinx-chipdb.overrideAttrs (_: _: { backends = [ "artiz7" ]; });
-          kintex7 = final._nextpnr-xilinx-chipdb.overrideAttrs (_: _: { backends = [ "kintex7" ]; });
-          spartan7 = final._nextpnr-xilinx-chipdb.overrideAttrs (_: _: { backends = [ "spartan7" ]; });
-          zynq7 = final._nextpnr-xilinx-chipdb.overrideAttrs (_: _: { backends = [ "zynq7" ]; });
+          artiz7 = _nextpnr-xilinx-chipdb;   # .override { backend = "artiz7"; };
+          kintex7 = _nextpnr-xilinx-chipdb;  # .override { backend = "kintex7"; };
+          spartan7 = _nextpnr-xilinx-chipdb; # .override { backend = "spartan7"; };
+          zynq7 = _nextpnr-xilinx-chipdb;    # .override { backend = "zynq7"; };
         };
 
-        _nextpnr-xilinx-chipdb = with final; stdenv.mkDerivation rec {
+        _nextpnr-xilinx-chipdb = with prev; stdenv.mkDerivation rec {
           pname = "nextpnr-xilinx-chipdb";
           version = nextpnr-xilinx.version;
-          backends = [ "artiz7" "kintex7" "spartan7" "zynq7" ];
+          backend = "zynq7";
 
           src = "${nextpnr-xilinx.outPath}/usr/share/nextpnr/external/prjxray-db";
 
@@ -394,9 +394,6 @@
               uniq >\
             $out/footprints.txt
 
-            cat $out/footprints.txt
-            exit 1
-
             for i in `cat $out/footprints.txt`
             do
                 if   [[ $i = xc7a* ]]; then ARCH=artix7 
@@ -408,7 +405,7 @@
                   exit 1
                 fi
 
-                if [[ $ARCH != ${backends} ]]; then
+                if [[ $ARCH != "${backend}" ]]; then
                   continue
                 fi
 
@@ -418,6 +415,12 @@
                 bbasm -l $i.bba $out/$i.bin
             done
           '';
+
+          # FIXME(jleightcap): the above buildPhase is adapated from a `builder`; which combines the process of
+          # compiling assets along with installing those assets to `$out`.
+          # These steps should be untangled, ideally - for now just use the buildPhase and disable the (empty)
+          # installPhase.
+          dontInstall = true;
         };
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -371,56 +371,10 @@
         };
 
         nextpnr-xilinx-chipdb = {
-          artiz7 = _nextpnr-xilinx-chipdb;   # .override { backend = "artiz7"; };
-          kintex7 = _nextpnr-xilinx-chipdb;  # .override { backend = "kintex7"; };
-          spartan7 = _nextpnr-xilinx-chipdb; # .override { backend = "spartan7"; };
-          zynq7 = _nextpnr-xilinx-chipdb;    # .override { backend = "zynq7"; };
-        };
-
-        _nextpnr-xilinx-chipdb = with prev; stdenv.mkDerivation rec {
-          pname = "nextpnr-xilinx-chipdb";
-          version = nextpnr-xilinx.version;
-          backend = "zynq7";
-
-          src = "${nextpnr-xilinx.outPath}/usr/share/nextpnr/external/prjxray-db";
-
-          inherit (pkgs) coreutils findutils gnused gnugrep;
-          buildInputs = [ prjxray nextpnr-xilinx pypy3 coreutils findutils gnused gnugrep ];
-          buildPhase = ''
-            mkdir -p $out
-            find ${src}/ -type d -name "*-*" -mindepth 1 -maxdepth 2 |\
-              sed -e 's,.*/\(.*\)-.*$,\1,g' -e 's,\./,,g' |\
-              sort |\
-              uniq >\
-            $out/footprints.txt
-
-            for i in `cat $out/footprints.txt`
-            do
-                if   [[ $i = xc7a* ]]; then ARCH=artix7 
-                elif [[ $i = xc7k* ]]; then ARCH=kintex7
-                elif [[ $i = xc7s* ]]; then ARCH=spartan7
-                elif [[ $i = xc7z* ]]; then ARCH=zynq7
-                else 
-                  echo "unsupported architecture for footprint $i"
-                  exit 1
-                fi
-
-                if [[ $ARCH != "${backend}" ]]; then
-                  continue
-                fi
-
-                FIRST_SPEEDGRADE_DIR=`ls -d ${src}/$ARCH/$i-* | sort -n | head -1`
-                FIRST_SPEEDGRADE=`echo $FIRST_SPEEDGRADE_DIR | tr '/' '\n' | tail -1`
-                pypy3.9 ${nextpnr-xilinx}/usr/share/nextpnr/python/bbaexport.py --device $FIRST_SPEEDGRADE --bba $i.bba 2>&1
-                bbasm -l $i.bba $out/$i.bin
-            done
-          '';
-
-          # FIXME(jleightcap): the above buildPhase is adapated from a `builder`; which combines the process of
-          # compiling assets along with installing those assets to `$out`.
-          # These steps should be untangled, ideally - for now just use the buildPhase and disable the (empty)
-          # installPhase.
-          dontInstall = true;
+          artiz7 = prev.callPackage ./nix/nextpnr-xilinx-chipdb.nix { backend = "artiz7"; };
+          kintex7 = prev.callPackage ./nix/nextpnr-xilinx-chipdb.nix { backend = "kintex7"; };
+          spartan7 = prev.callPackage ./nix/nextpnr-xilinx-chipdb.nix { backend = "spartan7"; };
+          zynq7 = prev.callPackage ./nix/nextpnr-xilinx-chipdb.nix { backend = "zynq7"; };
         };
       };
 

--- a/nix/nextpnr-xilinx-chipdb.nix
+++ b/nix/nextpnr-xilinx-chipdb.nix
@@ -1,0 +1,47 @@
+{ stdenv, backend, nextpnr-xilinx, prjxray, pypy3, coreutils
+, findutils, gnused, gnugrep, ... }:
+stdenv.mkDerivation rec {
+  pname = "nextpnr-xilinx-chipdb";
+  version = nextpnr-xilinx.version;
+  inherit backend;
+
+  src = "${nextpnr-xilinx.outPath}/usr/share/nextpnr/external/prjxray-db";
+
+  buildInputs =
+    [ prjxray nextpnr-xilinx pypy3 coreutils findutils gnused gnugrep ];
+  buildPhase = ''
+    mkdir -p $out
+    find ${src}/ -type d -name "*-*" -mindepth 1 -maxdepth 2 |\
+      sed -e 's,.*/\(.*\)-.*$,\1,g' -e 's,\./,,g' |\
+      sort |\
+      uniq >\
+    $out/footprints.txt
+
+    for i in `cat $out/footprints.txt`
+    do
+        if   [[ $i = xc7a* ]]; then ARCH=artix7 
+        elif [[ $i = xc7k* ]]; then ARCH=kintex7
+        elif [[ $i = xc7s* ]]; then ARCH=spartan7
+        elif [[ $i = xc7z* ]]; then ARCH=zynq7
+        else 
+          echo "unsupported architecture for footprint $i"
+          exit 1
+        fi
+
+        if [[ $ARCH != "${backend}" ]]; then
+          continue
+        fi
+
+        FIRST_SPEEDGRADE_DIR=`ls -d ${src}/$ARCH/$i-* | sort -n | head -1`
+        FIRST_SPEEDGRADE=`echo $FIRST_SPEEDGRADE_DIR | tr '/' '\n' | tail -1`
+        pypy3.9 ${nextpnr-xilinx}/usr/share/nextpnr/python/bbaexport.py --device $FIRST_SPEEDGRADE --bba $i.bba 2>&1
+        bbasm -l $i.bba $out/$i.bin
+    done
+  '';
+
+  # FIXME(jleightcap): the above buildPhase is adapated from a `builder`; which combines the process of
+  # compiling assets along with installing those assets to `$out`.
+  # These steps should be untangled, ideally - for now just use the buildPhase and disable the (empty)
+  # installPhase.
+  dontInstall = true;
+}


### PR DESCRIPTION
(In response to https://github.com/ngi-nix/ngipkgs/issues/7#issuecomment-1695354643)

We started by refactoring the `builder = ...` attribute of the `nextpnr-xilinx-chipdb` derivation. This builder script had the neccessary build logic for interacting with the prjxray-db, but had some glue logic for interacting with the external dependencies.

We refactored this to be inline shell script in the derivation definition, porting over the build logic.
We left a note about future work splitting out the installPhase.

We took a look at your comment, 

> Also, I would like to call the builder with different arguments to create different flakes with the different FPGA families (artiz7, kintex7, spartan7 zynq7). What would be the best way to go about it?
I also would like to make those optional. How would I want to do that?

Our thought was to have a 'base' derivation for `nextpnr-xilinx-chipdb`, then configure the `backend` based on overrides. Ideally, the building process looks like

```
nix build .#nextpnr-xilinx-chipdb.zynq7 # only includes zynq7
# ...
```

Let us know if that's along the lines you were thinking @hansfbaier!