### PR TITLE
fasm: patch ignored runtime dependency warnings

### DIFF
--- a/nix/fasm/default.nix
+++ b/nix/fasm/default.nix
@@ -33,7 +33,9 @@ buildPythonPackage rec {
     hash = "sha256-oC6vSpI9u8gEA2C85k00WdXzpH5GxeqtfNqqMduW5Jg=";
   };
 
-  patches = map fetchPatchFromAur [
+  patches = [
+    ./textx-default.patch
+  ] ++ (map fetchPatchFromAur [
     {
       name = "0001-cmake-install-parse_fasm.so.patch";
       sha256 = "sha256-ZEq/hTXjCIkVkWhgCYWtRe3wftdYMNwhNC4KNnBI2Dc=";
@@ -70,7 +72,7 @@ buildPythonPackage rec {
       name = "0009-Use-cmake-directly-instead-of-letting-setup.py-try-t.patch";
       sha256 = "sha256-/Ay+XjTE7MPcQg5yeo7zuKE2T/tE/P1sIMxgRYeSWNI=";
     }
-  ];
+  ]);
 
 
   nativeBuildInputs = [

--- a/nix/fasm/textx-default.patch
+++ b/nix/fasm/textx-default.patch
@@ -1,0 +1,32 @@
+diff --git a/fasm/parser/__init__.py b/fasm/parser/__init__.py
+index edd02e4..9d188e0 100644
+--- a/fasm/parser/__init__.py
++++ b/fasm/parser/__init__.py
+@@ -22,25 +22,8 @@ from warnings import warn
+ available = []
+ """ List of parser submodules available. Strings should match module names. """
+ 
+-try:
+-    from fasm.parser.antlr import \
+-        parse_fasm_filename, parse_fasm_string, implementation
+-    available.append('antlr')
+-except ImportError as e:
+-    warn(
+-        """Unable to import fast Antlr4 parser implementation.
+-  ImportError: {}
+-
+-  Falling back to the much slower pure Python textX based parser
+-  implementation.
+-
+-  Getting the faster antlr parser can normally be done by installing the
+-  required dependencies and then reinstalling the fasm package with:
+-    pip uninstall
+-    pip install -v fasm
+-""".format(e), RuntimeWarning)
+-    from fasm.parser.textx import \
+-        parse_fasm_filename, parse_fasm_string, implementation
++from fasm.parser.textx import \
++    parse_fasm_filename, parse_fasm_string, implementation
+ 
+ # The textx parser is available as a fallback.
+ available.append('textx')


### PR DESCRIPTION
see:
https://github.com/ngi-nix/projects/issues/5#issuecomment-1751297679

fasm provides two options for runtime parsing: `textx` and ANTLR4.

ANTLR4 is:

- not immediately in nixpkgs as a C++ runtime with compatible CMake
  hooks
- not easily exposed in the fasm build scripts.

There is an Arch Linux specific workaround on an unmerged branch.

For the time being, fall back to the flower `textx` parser and patch out
the runtime warning:

```
RuntimeWarning: Unable to import fast Antlr4 parser implementation.
      ImportError: cannot import name tags

      Falling back to the much slower pure Python textX based parser
      implementation.

      Getting the faster antlr parser can normally be done by installing the
      required dependencies and then reinstalling the fasm package with:
        pip uninstall
        pip install -v fasm

      warn(
```

Thanks for the tip @fricklerhandwerk!

Signed-off-by: Jack Leightcap <jack@leightcap.com>
