### PR TITLE
libantlr4cpp: init at 4.13.1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,19 @@
               inherit buildPythonPackage pythonOlder textx cython fetchpatch;
             };
 
+          libantlr4cpp = callPackage ./nix/libantlr4cpp { };
+
+          fasm = with pkgs;
+            with python3Packages;
+            callPackage ./nix/fasm {
+              # NOTE(jleightcap): calling this package here is clucky.
+              # contorted structure here to make the `nix/fasm` directory be
+              # drop-in to upstream python-modules in nixpkgs.
+              inherit buildPythonPackage pythonOlder textx cython fetchpatch;
+            };
+
+          libantlr4cpp = callPackage ./nix/libantlr4cpp { };
+
           nextpnr-xilinx-chipdb = {
             artix7 = callPackage ./nix/nextpnr-xilinx-chipdb.nix {
               backend = "artix7";

--- a/nix/libantlr4cpp/default.nix
+++ b/nix/libantlr4cpp/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, fetchzip
+, substituteAll
+, cmake
+, python3
+, gtest
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libantlr4cpp";
+  version = "4.13.1";
+  src = fetchzip {
+    url = "https://www.antlr.org/download/antlr4-cpp-runtime-${version}-source.zip";
+    sha256 ="sha256-w95wxbC2X4zDewt/HqRaEXsADUhwQepi8S2MwVa9m0k=";
+    stripRoot = false;
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./dont_fetch_dependencies.patch;
+      gtest_src = gtest.src;
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    python3
+  ];
+
+  # FIXME(jleightcap): validate cross-compilation to i686
+  /*
+  configureFlags = lib.optional stdenv.is64bit "--enable-64bit"
+    # libantlr3c wrongly emits the abi flags -m64 and -m32 which imply x86 archs
+    # https://github.com/antlr/antlr3/issues/205
+    ++ lib.optional (!stdenv.hostPlatform.isx86) "--disable-abiflags";
+  */
+
+  meta = with lib; {
+    description = "C++ runtime libraries of ANTLR v4";
+    homepage = "https://www.antlr.org/";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    # FIXME(jleightcap): add https://github.com/antlr/antlr4/releases/tag/4.13.1 changelog
+    maintainers = with maintainers; [ jleightcap ];
+  };
+}

--- a/nix/libantlr4cpp/dont_fetch_dependencies.patch
+++ b/nix/libantlr4cpp/dont_fetch_dependencies.patch
@@ -1,0 +1,22 @@
+diff --git a/runtime/CMakeLists.txt b/runtime/CMakeLists.txt
+index 86fdab9..e512fcd 100644
+--- a/runtime/CMakeLists.txt
++++ b/runtime/CMakeLists.txt
+@@ -62,7 +62,7 @@ if (ANTLR_BUILD_CPP_TESTS)
+ 
+   FetchContent_Declare(
+     googletest
+-    URL https://github.com/google/googletest/archive/e2239ee6043f73722e7aa812a459f54a28552929.zip
++    SOURCE_DIR @gtest_src@
+   )
+ 
+   if(WITH_STATIC_CRT)
+@@ -158,7 +158,7 @@ if (ANTLR_BUILD_CPP_TESTS)
+       COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:antlr4_shared> ${CMAKE_HOME_DIRECTORY}/dist
+       COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_LINKER_FILE:antlr4_shared> ${CMAKE_HOME_DIRECTORY}/dist)
+   endif()
+-  
++
+   if (TARGET antlr4_static)
+     add_custom_command(
+       TARGET antlr4_static


### PR DESCRIPTION
package ANTLR4 C++ runtime.
for upstream, this should be merged into the existing nixpkgs `antlr4`
meta-package.

(CC @albertchae)

Signed-off-by: Jack Leightcap <jack@leightcap.com>
