### PR TITLE
nextpnr-xilinx: fix build on macOS

### DIFF
--- a/nix/nextpnr-xilinx.nix
+++ b/nix/nextpnr-xilinx.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake git ];
   buildInputs = [ python312Packages.boost python312 eigen ]
-    ++ (lib.optional stdenv.cc.isClang [ llvmPackages.openmp ]);
+    ++ (lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ]);
 
   cmakeFlags = [
     "-DCURRENT_GIT_VERSION=${lib.substring 0 7 src.rev}"


### PR DESCRIPTION
It was broken by e1d67e0; it looks like it was an attempt to switch to lib.optionals, but forgot the s?